### PR TITLE
minor, MQTT topic structures made consistent

### DIFF
--- a/transf-mqtt-v1.0-wd01.md
+++ b/transf-mqtt-v1.0-wd01.md
@@ -284,12 +284,11 @@ would subscribe to `oc2/cmd/ap/slpf`.
 In order to receive commands intended for its security 
 functions, a Consumer device registering with the broker 
 would subscribe to:
-* `oc2/cmd/actuator_profile` for all APs the device implements
-* `oc2/cmd/device_type` for that device's TYPE
-* `oc2/cmd/device_id` for that device's ID
-* `oc2/cmd/action_target` for the union set of commands supported by the set of APs the device implements
-* `oc2/cmd/action` for the union set of actions 
-supported by the set of APs the device implements
+* `oc2/cmd/ap/[acutator_profile]` for all actuator profiles the device implements
+* `oc2/cmd/device_type/[device_type]` for that device's TYPE
+* `oc2/cmd/device_id/[device_type]` for that device's ID
+* `oc2/cmd/action_target/[action_target]` for all action-target pairs in the union set of actuator profiles the device implements
+* `oc2/cmd/action/[action]` for all actions in the union set of actuator profiles the device implements
 
 In order to receive responses to the commands is sends, 
 a Producer registering with the broker would subscribe to:


### PR DESCRIPTION
I don't yet see the value of having an "actions" topic; but left as is.